### PR TITLE
PAR-8157-schneider-dlm-es-toltok-default-meter-value-kezelese

### DIFF
--- a/src/main/java/net/parkl/ocpp/repositories/TransactionEnergyImportLegacyRepository.java
+++ b/src/main/java/net/parkl/ocpp/repositories/TransactionEnergyImportLegacyRepository.java
@@ -18,9 +18,9 @@
  */
 package net.parkl.ocpp.repositories;
 
-import net.parkl.ocpp.entities.TransactionEnergyImport;
+import net.parkl.ocpp.entities.TransactionEnergyImportLegacy;
 import org.springframework.data.repository.CrudRepository;
 
-public interface TransactionEnergyImportLegacyRepository extends CrudRepository<TransactionEnergyImport, Integer> {
+public interface TransactionEnergyImportLegacyRepository extends CrudRepository<TransactionEnergyImportLegacy, Integer> {
 
 }


### PR DESCRIPTION
Updated the repository to use `TransactionEnergyImportLegacy` instead of `TransactionEnergyImport`. This change ensures alignment with the entity naming convention and prevents potential mismatches in usage.