### PR TITLE
Update parkl.backend.api.version to 1.7.63

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 
         <jakarta.ee.web.api.version>10.0.0</jakarta.ee.web.api.version>
         <jakarta.xml.ws.api.version>4.0.0</jakarta.xml.ws.api.version>
-        <parkl.backend.api.version>1.7.62-Par-9094-analytics</parkl.backend.api.version>
+        <parkl.backend.api.version>1.7.63</parkl.backend.api.version>
 
         <mysql.jdbc.version>8.4.0</mysql.jdbc.version>
 


### PR DESCRIPTION
Upgraded the parkl.backend.api.version from 1.7.62-Par-9094-analytics to 1.7.63 for consistency and improved dependency management. This ensures compatibility with the latest backend API changes.