### PR TITLE
Refactor Entity: Move @Id annotation to chargeBoxId.

### DIFF
--- a/src/main/java/net/parkl/ocpp/entities/WebSocketClusterSession.java
+++ b/src/main/java/net/parkl/ocpp/entities/WebSocketClusterSession.java
@@ -13,13 +13,13 @@ import java.time.LocalDateTime;
 @Getter
 @Setter
 public class WebSocketClusterSession implements Serializable {
-    @Id
     @Column(name = "session_id")
     private String sessionId;
 
     @Column(name = "pod_ip", nullable = false, length = 30)
     private String podIp;
 
+    @Id
     @Column(name = "charge_box_id", nullable = false)
     private String chargeBoxId;
 


### PR DESCRIPTION
The @Id annotation was moved from sessionId to chargeBoxId in the WebSocketClusterSession class. This change ensures correct identification of the primary key in the database schema. It aligns the entity definition with the intended data model.